### PR TITLE
Logging enablement for Jellyfin via filebeat

### DIFF
--- a/jellyfin/Chart.yaml
+++ b/jellyfin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jellyfin
 description: Media server for hosting movies and shows
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "10.11.1"

--- a/jellyfin/templates/jellyfin.yaml
+++ b/jellyfin/templates/jellyfin.yaml
@@ -19,13 +19,13 @@ spec:
     metadata:
       labels:
         app: jellyfin
-      annotations:
-        co.elastic.logs/enabled: "true"
-        co.elastic.logs/json.keys_under_root: "false"
-        co.elastic.logs/json.add_error_key: "false"
-        co.elastic.logs/multiline.pattern: '^\['
-        co.elastic.logs/multiline.negate: "true"
-        co.elastic.logs/multiline.match: "after"
+      #annotations:
+      #  co.elastic.logs/enabled: "true"
+      #  co.elastic.logs/json.keys_under_root: "false"
+      #  co.elastic.logs/json.add_error_key: "false"
+      #  co.elastic.logs/multiline.pattern: '^\['
+      #  co.elastic.logs/multiline.negate: "true"
+      #  co.elastic.logs/multiline.match: "after"
     spec:
       containers:
         - name: jellyfin

--- a/jellyfin/templates/jellyfin.yaml
+++ b/jellyfin/templates/jellyfin.yaml
@@ -19,13 +19,13 @@ spec:
     metadata:
       labels:
         app: jellyfin
-      #annotations:
-      #  co.elastic.logs/enabled: "true"
-      #  co.elastic.logs/json.keys_under_root: "false"
-      #  co.elastic.logs/json.add_error_key: "false"
-      #  co.elastic.logs/multiline.pattern: '^\['
-      #  co.elastic.logs/multiline.negate: "true"
-      #  co.elastic.logs/multiline.match: "after"
+      annotations:
+        co.elastic.logs/enabled: "true"
+        co.elastic.logs/json.keys_under_root: "false"
+        co.elastic.logs/json.add_error_key: "false"
+        co.elastic.logs/multiline.pattern: '^\['
+        co.elastic.logs/multiline.negate: "true"
+        co.elastic.logs/multiline.match: "after"
     spec:
       containers:
         - name: jellyfin

--- a/jellyfin/templates/jellyfin.yaml
+++ b/jellyfin/templates/jellyfin.yaml
@@ -20,9 +20,7 @@ spec:
       labels:
         app: jellyfin
       annotations:
-        co.elastic.logs/enabled: "true"
-        co.elastic.logs/json.keys_under_root: "false"
-        co.elastic.logs/json.add_error_key: "false"
+        co.elastic.logs/enabled: "{{ .Values.logging.enabled }}"
         co.elastic.logs/multiline.pattern: '^\['
         co.elastic.logs/multiline.negate: "true"
         co.elastic.logs/multiline.match: "after"

--- a/jellyfin/templates/jellyfin.yaml
+++ b/jellyfin/templates/jellyfin.yaml
@@ -19,6 +19,13 @@ spec:
     metadata:
       labels:
         app: jellyfin
+      annotations:
+        co.elastic.logs/enabled: "true"
+        co.elastic.logs/json.keys_under_root: "false"
+        co.elastic.logs/json.add_error_key: "false"
+        co.elastic.logs/multiline.pattern: '^\['
+        co.elastic.logs/multiline.negate: "true"
+        co.elastic.logs/multiline.match: "after"
     spec:
       containers:
         - name: jellyfin

--- a/jellyfin/values.yaml
+++ b/jellyfin/values.yaml
@@ -21,3 +21,6 @@ ingress:
   hosts:
     - jellyfin.media.local
     - 192.168.29.9.nip.io
+
+logging:
+  enabled: true


### PR DESCRIPTION
Enable logging metrics to be forwarded to Logstahs via Filebeat for log management in a search engine