### PR TITLE
Support logging for Jenkins

### DIFF
--- a/jenkins/Chart.yaml
+++ b/jenkins/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jenkins
 description: CICD Pipeline tool for managing application release deployment
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "2.534.0"

--- a/jenkins/templates/jenkins.yaml
+++ b/jenkins/templates/jenkins.yaml
@@ -19,6 +19,11 @@ spec:
     metadata:
       labels:
         app: jenkins
+      annotations:
+        co.elastic.logs/enabled: "{{ .Values.logging.enabled }}"
+        co.elastic.logs/multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+        co.elastic.logs/multiline.negate: "true"
+        co.elastic.logs/multiline.match: "after"
     spec:
       containers:
         - name: jenkins

--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -10,3 +10,6 @@ ingress:
   enabled: true
   hosts:
     - jenkins.pipeline.local
+
+logging:
+  enabled: true


### PR DESCRIPTION
- Jenkins logs can be fetched and pushed to any search engine via filebeat and logstash